### PR TITLE
Fix Bug: Examinee can't see invalid function in the Exam

### DIFF
--- a/src/app/pages/exam/ide.plugin.ts
+++ b/src/app/pages/exam/ide.plugin.ts
@@ -2,20 +2,25 @@ import {IdeCommands, IdePlugin, IdeViewModel} from '../ide/ide.plugin';
 import {ExamContext} from '../../contexts/ExamContext';
 import {Injectable} from '@angular/core';
 import {Location} from '@angular/common';
-import {findQuestion, isExamClosed} from '../../models';
+import {findQuestion, isExamClosed, Problem} from '../../models';
 import {ProblemContext} from '../../contexts/ProblemContext';
-import {ActivatedRoute, Params, Router} from '@angular/router';
+import {ActivatedRoute, Router} from '@angular/router';
 import {combineLatest, Observable} from 'rxjs';
 import {map} from 'rxjs/operators';
+import {ExamService} from '../../services/Services';
 
 
 @Injectable({providedIn: 'root'})
 export class ExamIdePlugin extends IdePlugin {
+  private examId: number;
+
   constructor(private examContext: ExamContext,
               private problemContext: ProblemContext,
+              private examService: ExamService,
               private location: Location,
               private router: Router) {
     super();
+    this.examContext.exam$.subscribe(exam => this.examId = exam.id);
   }
 
   commands(route: ActivatedRoute): IdeCommands {
@@ -50,5 +55,9 @@ export class ExamIdePlugin extends IdePlugin {
           }
         };
       }));
+  }
+
+  getProblem(problemId: number): Observable<Problem> {
+    return this.examService.getProblem(problemId, this.examId);
   }
 }

--- a/src/app/pages/ide/ide.component.ts
+++ b/src/app/pages/ide/ide.component.ts
@@ -45,6 +45,7 @@ export class IdeComponent implements OnInit, OnDestroy, AfterViewInit {
   problem$: Observable<Problem>;
   private ideCommands: IdeCommands;
   private ideViewModel$: Observable<IdeViewModel>;
+  private getProblem$: Observable<Problem>;
 
   constructor(private problemService: ProblemService,
               private problemContext: ProblemContext,
@@ -57,12 +58,13 @@ export class IdeComponent implements OnInit, OnDestroy, AfterViewInit {
     const idePlugin = injector.get<IdePlugin>(route.snapshot.data.idePluginProvider);
     this.ideCommands = idePlugin.commands(route);
     this.ideViewModel$ = idePlugin.viewModel$;
+    this.getProblem$ = idePlugin.getProblem(this.problemId);
     this.banner$ = this.ideViewModel$.pipe(map(vm => vm.banner));
   }
 
   ngOnInit(): void {
-    this.problemService.getProblem(this.problemId)
-      .toPromise().then(problem => this.problemContext.initializeProblem(problem))
+    this.getProblem$.toPromise()
+      .then(problem => this.problemContext.initializeProblem(problem))
       .catch(err => this.problemContext.problemNotFound(err));
   }
 

--- a/src/app/pages/ide/ide.default.plugin.ts
+++ b/src/app/pages/ide/ide.default.plugin.ts
@@ -1,13 +1,16 @@
 import {IdeCommands, IdePlugin, IdeViewModel} from './ide.plugin';
 import {Injectable} from '@angular/core';
 import {ProblemContext} from '../../contexts/ProblemContext';
-import {ActivatedRoute, Params, Router} from '@angular/router';
-import {NEVER, Observable, of} from 'rxjs';
+import {ActivatedRoute, Router} from '@angular/router';
+import {NEVER, Observable} from 'rxjs';
+import {Problem} from '../../models';
+import {ProblemService} from '../../services/Services';
 
 
 @Injectable({providedIn: 'root'})
 export class DefaultIdePlugin extends IdePlugin {
   constructor(private problemContext: ProblemContext,
+              private problemService: ProblemService,
               private router: Router) {
     super();
   }
@@ -25,5 +28,9 @@ export class DefaultIdePlugin extends IdePlugin {
 
   get viewModel$(): Observable<IdeViewModel> {
     return NEVER;
+  }
+
+  getProblem(problemId: number): Observable<Problem> {
+    return this.problemService.getProblem(problemId);
   }
 }

--- a/src/app/pages/ide/ide.plugin.ts
+++ b/src/app/pages/ide/ide.plugin.ts
@@ -1,11 +1,13 @@
 import {Banner} from './ide.component';
-import {ActivatedRoute, Params} from '@angular/router';
+import {ActivatedRoute} from '@angular/router';
 import {Observable} from 'rxjs';
 import {CodeUploadPanelDecorator} from './code-panel/code-upload-panel.component';
+import {Problem} from '../../models';
 
 export abstract class IdePlugin {
   abstract get viewModel$(): Observable<IdeViewModel>;
   abstract commands(route: ActivatedRoute): IdeCommands;
+  abstract getProblem(problemId: number): Observable<Problem>;
 }
 
 export interface IdeViewModel {

--- a/src/app/services/Services.ts
+++ b/src/app/services/Services.ts
@@ -74,6 +74,8 @@ export abstract class ExamService {
 
   abstract getExamsByStudentId(studentId: number, examStatus?: ExamStatus,
                                skip?: number, size?: number): Observable<ExamItem[]>;
+
+  abstract getProblem(problemId: number, examId: number): Observable<Problem>;
 }
 
 @Injectable({

--- a/src/app/services/impl/HttpExamService.ts
+++ b/src/app/services/impl/HttpExamService.ts
@@ -1,10 +1,11 @@
 import {ExamService} from '../Services';
 
 import {Observable} from 'rxjs';
-import {ExamItem, ExamOverview} from '../../models';
+import {ExamItem, ExamOverview, Problem} from '../../models';
 import {HttpClient} from '@angular/common/http';
 import {Injectable} from '@angular/core';
 import {environment} from '../../../environments/environment';
+import {map} from 'rxjs/operators';
 
 @Injectable({
   providedIn: 'root'
@@ -24,6 +25,16 @@ export class HttpExamService extends ExamService {
   getExamsByStudentId(studentId: number, examStatus: ExamStatus = ExamStatus.all,
                       skip: number = 0, size: number = 50): Observable<ExamItem[]> {
     return this.http.get<ExamItem[]>(`${this.baseUrl}/api/students/${studentId}/exams?status=${examStatus}&&skip=${skip}&&size=${size}`);
+  }
+
+  getProblem(problemId: number, examId: number): Observable<Problem> {
+    return this.http.get(`${this.baseUrl}/api/exams/${examId}/problems/${problemId}`)
+      .pipe(map(body => this.toProblem(body)));
+  }
+
+  toProblem(body): Problem {
+    return new Problem(body.id, body.title, body.description, body.tags, body.languageEnvs,
+      body.testcases);
   }
 }
 

--- a/src/app/services/impl/HttpExamService.ts
+++ b/src/app/services/impl/HttpExamService.ts
@@ -32,7 +32,7 @@ export class HttpExamService extends ExamService {
       .pipe(map(body => this.toProblem(body)));
   }
 
-  toProblem(body): Problem {
+  private toProblem(body): Problem {
     return new Problem(body.id, body.title, body.description, body.tags, body.languageEnvs,
       body.testcases);
   }

--- a/src/app/services/impl/HttpSubmissionService.ts
+++ b/src/app/services/impl/HttpSubmissionService.ts
@@ -57,14 +57,11 @@ export class HttpSubmissionService extends SubmissionService {
   }
 
   getSubmittedCodes(problemId: number, submissionId: string, submittedCodesFileId: string): Observable<CodeFile[]> {
-    return this.problemService.getProblem(problemId)
-      .pipe(switchMap(() => {
-        return this.http.get(`${this.baseUrl}/api/problems/${problemId}/${DEFAULT_LANG_ENV}` +
+    return this.http.get(`${this.baseUrl}/api/problems/${problemId}/${DEFAULT_LANG_ENV}` +
           `/students/${this.studentId}/submissions/${submissionId}/submittedCodes/${submittedCodesFileId}`, {
           responseType: 'arraybuffer'
-        });
-      }))
-      .pipe(switchMap(unzipCodesArrayBuffer));
+        })
+    .pipe(switchMap(unzipCodesArrayBuffer));
   }
 
   private get studentId() {


### PR DESCRIPTION
In the current version, the examinee can only access visible problems because Exam and Problem share the same ide component and the `getProlem` API. When examinee access question page, it will trigger `getProblem` in Problem service.

Requirement: `IdeComponent` has different requirements in Problem and Exam scenarios. 
Fix: Extract `getProlem` method to the `idePlugin`.

![image](https://user-images.githubusercontent.com/41495987/146798481-ae2a1406-49e1-4546-a177-354a0e53af29.png)
